### PR TITLE
Add magento/module-aws-s3 to replacements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "magento/module-authorizenet-acceptjs": "*",
     "magento/module-authorizenet-cardinal": "*",
     "magento/module-authorizenet-graph-ql": "*",
+    "magento/module-aws-s3": "*",
     "magento/module-bundle-import-export": "*",
     "magento/module-catalog-analytics": "*",
     "magento/module-catalog-import-export": "*",


### PR DESCRIPTION
This module is only required by the community edition and could be replaced in my eyes.