### PR TITLE
Remove catalog import/export module from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
     "magento/module-bundle-import-export": "*",
     "magento/module-cardinal-commerce": "*",
     "magento/module-catalog-analytics": "*",
-    "magento/module-catalog-import-export": "*",
     "magento/module-catalog-page-builder-analytics": "*",
     "magento/module-cms-page-builder-analytics": "*",
     "magento/module-configurable-import-export": "*",


### PR DESCRIPTION
This (magento/module-catalog-url-rewrite) is required  in the latest magento version